### PR TITLE
fix: add node_modules to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .claude/settings.local.json
+node_modules/

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,3 @@
+const nextConfig = require("eslint-config-next");
+
+module.exports = nextConfig;

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint",
-    "test": "jest"
+    "lint": "eslint .",
+    "test": "jest --passWithNoTests"
   },
   "dependencies": {
     "next": "^16.0.0",


### PR DESCRIPTION
## Summary

- Add `node_modules/` to `.gitignore` (closes #3)
- Fix `npm run lint`: replace `next lint` (removed in Next.js 16) with `eslint .`
- Fix `npm test`: add `--passWithNoTests` so jest exits cleanly with no test files
- Add `eslint.config.js` using the `eslint-config-next` flat config

## Test plan

- [ ] `npm run lint` exits 0
- [ ] `npm test` exits 0
- [ ] `node_modules/` is no longer tracked by git

🤖 Generated with [Claude Code](https://claude.com/claude-code)