### PR TITLE
feat: create second page at /hello-mars

### DIFF
--- a/src/app/hello-mars/page.test.tsx
+++ b/src/app/hello-mars/page.test.tsx
@@ -1,0 +1,9 @@
+import { render, screen } from "@testing-library/react";
+import HelloMars from "./page";
+
+describe("HelloMars", () => {
+  it("renders Hello Mars heading", () => {
+    render(<HelloMars />);
+    expect(screen.getByRole("heading", { name: /hello mars/i })).toBeInTheDocument();
+  });
+});

--- a/src/app/hello-mars/page.tsx
+++ b/src/app/hello-mars/page.tsx
@@ -1,0 +1,7 @@
+export default function HelloMars() {
+  return (
+    <main className="flex min-h-screen items-center justify-center">
+      <h1 className="text-4xl font-bold">Hello Mars</h1>
+    </main>
+  );
+}


### PR DESCRIPTION
Closes #7

This PR creates a new page at the /hello-mars route with a simple 'Hello Mars' heading, matching the style of the existing Home page. Includes full test coverage.