### PR TITLE
feat: create Header component and add to pages

### DIFF
--- a/src/app/components/Header.test.tsx
+++ b/src/app/components/Header.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen } from "@testing-library/react";
+import Header from "./Header";
+
+describe("Header", () => {
+  it("renders the app title", () => {
+    render(<Header />);
+    expect(screen.getByRole("link", { name: /myapp/i })).toBeInTheDocument();
+  });
+
+  it("renders Home link", () => {
+    render(<Header />);
+    expect(screen.getByRole("link", { name: /home/i })).toBeInTheDocument();
+  });
+
+  it("renders Mars link", () => {
+    render(<Header />);
+    expect(screen.getByRole("link", { name: /mars/i })).toBeInTheDocument();
+  });
+
+  it("Home link points to root", () => {
+    render(<Header />);
+    const homeLink = screen.getByRole("link", { name: /home/i });
+    expect(homeLink).toHaveAttribute("href", "/");
+  });
+
+  it("Mars link points to hello-mars", () => {
+    render(<Header />);
+    const marsLink = screen.getByRole("link", { name: /mars/i });
+    expect(marsLink).toHaveAttribute("href", "/hello-mars");
+  });
+});

--- a/src/app/components/Header.tsx
+++ b/src/app/components/Header.tsx
@@ -1,0 +1,31 @@
+import Link from "next/link";
+
+export default function Header() {
+  return (
+    <header className="bg-gray-800 text-white shadow-lg">
+      <nav className="container mx-auto px-6 py-4 flex items-center justify-between">
+        <Link href="/" className="text-2xl font-bold hover:text-gray-300">
+          MyApp
+        </Link>
+        <ul className="flex gap-6">
+          <li>
+            <Link
+              href="/"
+              className="text-lg hover:text-gray-300 transition-colors"
+            >
+              Home
+            </Link>
+          </li>
+          <li>
+            <Link
+              href="/hello-mars"
+              className="text-lg hover:text-gray-300 transition-colors"
+            >
+              Mars
+            </Link>
+          </li>
+        </ul>
+      </nav>
+    </header>
+  );
+}

--- a/src/app/hello-mars/page.tsx
+++ b/src/app/hello-mars/page.tsx
@@ -1,7 +1,12 @@
+import Header from "../components/Header";
+
 export default function HelloMars() {
   return (
-    <main className="flex min-h-screen items-center justify-center">
-      <h1 className="text-4xl font-bold">Hello Mars</h1>
-    </main>
+    <>
+      <Header />
+      <main className="flex min-h-screen items-center justify-center">
+        <h1 className="text-4xl font-bold">Hello Mars</h1>
+      </main>
+    </>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,12 @@
+import Header from "./components/Header";
+
 export default function Home() {
   return (
-    <main className="flex min-h-screen items-center justify-center">
-      <h1 className="text-4xl font-bold">Hello World</h1>
-    </main>
+    <>
+      <Header />
+      <main className="flex min-h-screen items-center justify-center">
+        <h1 className="text-4xl font-bold">Hello World</h1>
+      </main>
+    </>
   );
 }


### PR DESCRIPTION
## Summary
Implements the Header component as specified in issue #9.

## Changes
- Created reusable Header component at `src/app/components/Header.tsx`
- Header includes navigation links to Home (`/`) and Mars (`/hello-mars`)
- Styled with Tailwind CSS with gray-800 background and hover effects
- Added Header component to home page (`src/app/page.tsx`)
- Added Header component to hello-mars page (`src/app/hello-mars/page.tsx`)
- Created comprehensive tests for Header component

## Testing
- All tests pass (`npm run lint && npm test`)
- Header component has 5 passing tests covering navigation links and attributes

Closes #9