### PR TITLE
chore: rename CLAUDE_MODEL var to WORKFLOW_CLAUDE_MODEL with Haiku fallback

### DIFF
--- a/.github/workflows/claude-build.yml
+++ b/.github/workflows/claude-build.yml
@@ -29,7 +29,7 @@ jobs:
 
     runs-on: ubuntu-latest
     env:
-      CLAUDE_MODEL: ${{ env.CLAUDE_MODEL }}
+      CLAUDE_MODEL: ${{ vars.WORKFLOW_CLAUDE_MODEL || 'claude-haiku-4-5-20251001' }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -55,9 +55,9 @@ jobs:
       - run: npm install -g @anthropic-ai/claude-code
 
       - name: Print model
-        run: echo "Using model: ${{ env.CLAUDE_MODEL }}"
+        run: 'echo "Using model: ${{ env.CLAUDE_MODEL }}"'
 
-# Flow 1: PR merged or manual trigger → pick next ticket
+      # Flow 1: PR merged or manual trigger → pick next ticket
       - name: Start next ticket
         if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
         run: |


### PR DESCRIPTION
- Rename `vars.CLAUDE_MODEL` to `vars.WORKFLOW_CLAUDE_MODEL` to clarify it's workflow-specific
- Restore safe fallback to `claude-haiku-4-5-20251001` if the variable is not set